### PR TITLE
Remove hard coded virtualenv load

### DIFF
--- a/cron_bano.sh
+++ b/cron_bano.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source /data/work/vdct/bano_venv37/bin/activate
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR
 


### PR DESCRIPTION
```
source /data/work/vdct/bano_venv37/bin/activate
```
Cette commande doit à la place être placé en préalable du lancement du script `cron_bano.sh` dans la commande du cron.
