### PR TITLE
[breaking change] load_osm_france_db

### DIFF
--- a/load_osm_france_db.sh
+++ b/load_osm_france_db.sh
@@ -5,12 +5,12 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/config
 
-lockfile=${SCRIPT_DIR}/imposm.lock
+lockfile=${DATA_DIR}/imposm.lock
 
 if test -f ${lockfile}
 then
-  echo `date`" : Process deja en cours" >> $SCRIPT_DIR/cron.log
-  exit 0
+  echo `date`" : Process deja en cours"
+  exit 1
 fi
 
 touch ${lockfile}


### PR DESCRIPTION
load_osm_france_db
- store lock in data not in source code, does not have side effect on source code dir
- exit with 1 on error with lock, exit 0 means "OK"
- does not log directly from the script, it is to caller to choose to redirect the script output
