### PR TITLE
Do not source venv from inside script

### DIFF
--- a/cron_bano.sh
+++ b/cron_bano.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source /data/project/bano_v3/venv_v3/bin/activate
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR
 

--- a/cron_osm.sh
+++ b/cron_osm.sh
@@ -2,8 +2,6 @@
 
 #set -e
 
-source /data/project/bano_v3/venv_v3/bin/activate
-
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $SCRIPT_DIR


### PR DESCRIPTION
Warning: breaking change.

The source command should be added to the crontab file.