### PR TITLE
Run scripts from project dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ sudo -u postgres -s "./create_base.sh"
 
 ## Chargement des données OSM
 
-Se placer dans le répertoire `DATA_DIR`, et appeler les scripts depuis là.
-
 Charger des données OSM depuis un pbf, France entière ou un extract plus petit.
 ```
 load_osm_france_db.sh

--- a/copy_table_from_osm_to_cadastre.sh
+++ b/copy_table_from_osm_to_cadastre.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $SCRIPT_DIR/config
+source config
 
 set -e
 

--- a/load_osm_france_db.sh
+++ b/load_osm_france_db.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $SCRIPT_DIR/config
+source config
 
 PBF_URL=${1:-http://download.openstreetmap.fr/extracts/merge/france_metro_dom_com_nc.osm.pbf}
 PBF_FILE=$(basename "$PBF_URL")

--- a/update_table_infos_communes.sh
+++ b/update_table_infos_communes.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR
+source config
 
 $pgsql_OSM -f ./sql/update_table_infos_communes.sql


### PR DESCRIPTION
À discuter.

Simplifie / aligne les scripts pour être lancé depuis le projet et non depuis ailleurs.