### PR TITLE
Ne filter pas uniquement sur le nom quand des noms alternatifs peuvent être utilisés

### DIFF
--- a/bano/sql/charge_noms_voies_lieux-dits_OSM.sql
+++ b/bano/sql/charge_noms_voies_lieux-dits_OSM.sql
@@ -14,7 +14,7 @@ FROM    (SELECT  1::integer AS provenance,
                      ELSE 'place'
                  END AS nature
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')                    p
-         JOIN    (SELECT * FROM planet_osm_point WHERE ("ref:FR:FANTOIR" !='' OR place != '') AND name != '') pt
+         JOIN    (SELECT * FROM planet_osm_point WHERE ("ref:FR:FANTOIR" !='' OR place != '')) pt
          ON      pt.way && p.way                 AND
                  ST_Intersects(pt.way, p.way)
          UNION ALL
@@ -24,7 +24,7 @@ FROM    (SELECT  1::integer AS provenance,
                  tags,
                  'voie'
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__') p
-         JOIN    (SELECT * FROM planet_osm_line WHERE highway != '' AND name != '')        l
+         JOIN    (SELECT * FROM planet_osm_line WHERE highway != '')        l
          ON      p.way && l.way AND ST_Contains(p.way, l.way)
          UNION ALL
          SELECT  3,
@@ -33,11 +33,11 @@ FROM    (SELECT  1::integer AS provenance,
                  tags,
                  'voie'
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')                                                                    p
-         JOIN    (SELECT * FROM planet_osm_polygon WHERE (highway||"ref:FR:FANTOIR" != '' OR landuse = 'residential' OR amenity = 'parking') AND name != '') pl
+         JOIN    (SELECT * FROM planet_osm_polygon WHERE (highway||"ref:FR:FANTOIR" != '' OR landuse = 'residential' OR amenity = 'parking')) pl
          ON      pl.way && p.way                 AND
                  ST_Intersects(pl.way, p.way)) l
 LEFT OUTER JOIN suffixe h
 ON      ST_Intersects(l.way, h.geometrie)
 LEFT OUTER JOIN (SELECT * FROM polygones_insee_a9 where insee_a8 = '__code_insee__') a9
 ON      ST_Contains(a9.geometrie,way)
-WHERE   l.name IS NOT NULL;
+WHERE   l.name != '' AND l.name IS NOT NULL;

--- a/bano/sql/charge_noms_voies_relation_OSM.sql
+++ b/bano/sql/charge_noms_voies_relation_OSM.sql
@@ -10,7 +10,7 @@ FROM    (SELECT 4::integer AS provenance,
                 l.way,
                 r.tags
          FROM   (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')    p
-         JOIN   (SELECT name,tags,osm_id,way FROM planet_osm_line WHERE highway != '' AND name != '') l
+         JOIN   (SELECT name,tags,osm_id,way FROM planet_osm_line WHERE highway != '') l
          ON     p.way && l.way AND ST_Contains(p.way, l.way)
          JOIN   planet_osm_rels r
          ON     r.osm_id = l.osm_id
@@ -20,7 +20,7 @@ FROM    (SELECT 4::integer AS provenance,
                 l.way,
                 r.tags
          FROM   (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')    p
-         JOIN   (SELECT name,tags,osm_id,way FROM planet_osm_polygon WHERE highway != '' AND name != '') l
+         JOIN   (SELECT name,tags,osm_id,way FROM planet_osm_polygon WHERE highway != '') l
          ON     p.way && l.way AND ST_Contains(p.way, l.way)
          JOIN   planet_osm_rels r
          ON     r.osm_id = l.osm_id) l
@@ -28,4 +28,4 @@ LEFT OUTER JOIN (SELECT * FROM suffixe WHERE code_insee = '__code_insee__') h
 ON            ST_Intersects(way, h.geometrie)
 LEFT OUTER JOIN (SELECT * FROM polygones_insee_a9 where insee_a8 = '__code_insee__') a9
 ON            ST_Contains(a9.geometrie,way)
-WHERE l.name IS NOT NULL;
+WHERE l.name != '' AND l.name IS NOT NULL;

--- a/bano/sql/charge_points_nommes_centroides_OSM.sql
+++ b/bano/sql/charge_points_nommes_centroides_OSM.sql
@@ -15,8 +15,7 @@ LEFT OUTER JOIN (SELECT * FROM polygones_insee_a9 WHERE insee_a8 = '__code_insee
 ON      ST_Intersects(l.way, a9.geometrie)
 WHERE   (l.highway != '' OR
         l.waterway = 'dam')     AND
-        l.highway NOT IN ('bus_stop','platform') AND
-        l.name != ''
+        l.highway NOT IN ('bus_stop','platform')
 UNION ALL
 SELECT  ST_PointOnSurface(l.way),
         unnest(array[l.name,l.tags->'alt_name',l.tags->'old_name']) AS name,
@@ -31,8 +30,7 @@ ON      ST_Intersects(l.way, p.geometrie)
 LEFT OUTER JOIN (SELECT * FROM polygones_insee_a9 WHERE insee_a8 = '__code_insee__') a9
 ON      ST_Intersects(l.way, a9.geometrie)
 WHERE   (l.highway||"ref:FR:FANTOIR" != '' OR l.landuse = 'residential' OR l.amenity = 'parking') AND
-        l.highway NOT IN ('bus_stop','platform') AND
-        l.name != ''
+        l.highway NOT IN ('bus_stop','platform')
 UNION ALL
 SELECT l.way,
         unnest(array[l.name,l.tags->'alt_name',l.tags->'old_name']) AS name,
@@ -46,18 +44,17 @@ JOIN    planet_osm_rels l
 ON      ST_Intersects(l.way, p.way)
 LEFT OUTER JOIN (SELECT * FROM polygones_insee_a9 WHERE insee_a8 = '__code_insee__') a9
 ON      ST_Intersects(l.way, a9.geometrie)
-WHERE   l.member_role = 'street' AND
-        l.name != ''),
+WHERE   l.member_role = 'street'),
 lignes_noms
 AS
-(SELECT CASE 
+(SELECT CASE
             WHEN GeometryType(way) = 'POINT' THEN ST_MakeLine(ST_Translate(way,-0.000001,-0.000001),ST_Translate(way,0.000001,0.000001))
             WHEN GeometryType(way) LIKE '%POLYGON' THEN ST_ExteriorRing(way)
             ELSE way
         END AS way_line,
         *
 FROM    lignes_brutes
-WHERE   name IS NOT NULL AND
+WHERE   name != '' AND name IS NOT NULL AND
         (fantoir LIKE '__code_insee__%' OR fantoir = '')),
 lignes_noms_rang
 AS

--- a/bano/sql/charge_points_nommes_places_OSM.sql
+++ b/bano/sql/charge_points_nommes_places_OSM.sql
@@ -7,9 +7,9 @@ AS
         place,
         a9.code_insee AS insee_ac,
         "ref:FR:FANTOIR" AS fantoir,
-        a9.nom AS nom_ac 
+        a9.nom AS nom_ac
 FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')                    p
-JOIN    (SELECT * FROM planet_osm_point WHERE place != '' AND name != '') pt
+JOIN    (SELECT * FROM planet_osm_point WHERE place != '') pt
 ON      pt.way && p.way                 AND
          ST_Intersects(pt.way, p.way)
 LEFT OUTER JOIN (SELECT osm_id FROM planet_osm_communes_statut WHERE "ref:INSEE" = '__code_insee__' AND member_role = 'admin_centre') admin_centre
@@ -24,4 +24,4 @@ SELECT  ST_x(way),
         fantoir,
         nom_ac
 FROM    pts
-WHERE   name IS NOT NULL;
+WHERE   name != '' AND name IS NOT NULL;


### PR DESCRIPTION
Ne filter pas uniquement sur le nom quand des noms alternatifs peuvent être utilisés.

J'ai supprimé les conditions, l'autre option est de mettre des conditions sur l’ensemble des champs name.