### PR TITLE
certification_commune

### DIFF
--- a/bano/models.py
+++ b/bano/models.py
@@ -220,6 +220,7 @@ class Adresse:
         code_insee_ancienne_commune=None,
         nom_ancienne_commune=None,
         id_ban=None,
+        certification_commune=None,
     ):
         self.code_insee = code_insee
         self.code_dept = hp.get_code_dept_from_insee(code_insee)
@@ -241,6 +242,7 @@ class Adresse:
             else "RACINE"
         )
         self.id_ban = id_ban
+        self.certification_commune = certification_commune
 
     def __hash__(self):
         return hash(
@@ -269,7 +271,7 @@ class Adresse:
             fantoir = remplace_fantoir_ban(correspondance, self.niveau, self.fantoir)
         else:
             fantoir = self.fantoir
-        return f"{fantoir if fantoir else ''}\t{self.x}\t{self.y}\t{self.numero}\t{self.voie if self.voie else ''}\t{self.place if self.place else ''}\t{self.code_postal}\t{self.code_insee}\t{self.code_dept}\t{self.code_insee_ancienne_commune if self.code_insee_ancienne_commune else ''}\t{self.nom_ancienne_commune if self.nom_ancienne_commune else ''}\t{self.source}\t{self.id_ban if self.id_ban else ''}"
+        return f"{fantoir if fantoir else ''}\t{self.x}\t{self.y}\t{self.numero}\t{self.voie if self.voie else ''}\t{self.place if self.place else ''}\t{self.code_postal}\t{self.code_insee}\t{self.code_dept}\t{self.code_insee_ancienne_commune if self.code_insee_ancienne_commune else ''}\t{self.nom_ancienne_commune if self.nom_ancienne_commune else ''}\t{self.source}\t{self.id_ban if self.id_ban else ''}\t{self.certification_commune if isinstance(self.certification_commune, int) else ''}"
 
     def _as_string(self):
         return f"source : {self.source}, numero : {self.numero}, voie : {self.voie} ({self.voie_normalisee}), place : {self.place}, fantoir : {self.fantoir}, code_postal:{self.code_postal}, sous_commune : {self.code_insee_ancienne_commune} - {self.nom_ancienne_commune}"
@@ -322,6 +324,7 @@ class Adresses:
             code_insee_ancienne_commune,
             nom_ancienne_commune,
             id_ban,
+            certification_commune,
         ) in data:
             if not (fantoir and fantoir in topo.topo):
                 fantoir = None
@@ -339,6 +342,7 @@ class Adresses:
                     code_insee_ancienne_commune=code_insee_ancienne_commune,
                     nom_ancienne_commune=nom_ancienne_commune,
                     id_ban=id_ban,
+                    certification_commune=certification_commune,
                 )
             )
 
@@ -506,6 +510,7 @@ class Adresses:
                     "nom_ancienne_commune",
                     "source",
                     "id_ban",
+                    "certification_commune",
                 ),
             )
 

--- a/bano/sql/charge_ban_commune.sql
+++ b/bano/sql/charge_ban_commune.sql
@@ -20,7 +20,8 @@ AS
         code_postal,
         code_insee_ancienne_commune,
         nom_ancienne_commune,
-        id
+        id,
+        certification_commune
 FROM    ban b
 LEFT OUTER JOIN rep_b_as_bis r
 USING   (fantoir,numero)
@@ -33,5 +34,6 @@ SELECT  fantoir,
         code_postal,
         code_insee_ancienne_commune,
         nom_ancienne_commune,
-        id
+        id,
+        certification_commune
 FROM    j;


### PR DESCRIPTION
maj de certification_commune dans bano_adresses
La colonne existe mais n'est pas remplie.
ça permet de s'en servir dans pifometre