### PR TITLE
Utilise ROW_NUMBER pour ne pas avoir de doublon du a des RANK execo

### DIFF
--- a/bano/sql/tables_export.sql
+++ b/bano/sql/tables_export.sql
@@ -95,7 +95,7 @@ USING  (code_insee)
 JOIN   (SELECT fantoir,
                lon,
                lat,
-               RANK() OVER (PARTITION BY fantoir ORDER BY CASE source WHEN 'OSM' THEN 1 WHEN 'BAN' THEN 3 ELSE 2 END, CASE nature WHEN 'centroide' THEN 2 ELSE 1 END) AS rang_par_fantoir
+               ROW_NUMBER() OVER (PARTITION BY fantoir ORDER BY CASE source WHEN 'OSM' THEN 1 WHEN 'BAN' THEN 3 ELSE 2 END, CASE nature WHEN 'centroide' THEN 2 ELSE 1 END) AS rang_par_fantoir
        FROM    bano_points_nommes
        WHERE   fantoir IS NOT NULL) AS pn
 USING  (fantoir)
@@ -140,7 +140,7 @@ AS
            ELSE ROUND(LOG(c.adm_weight+LOG(c.population+1)/3)::numeric*LOG(1+LOG(CASE WHEN nom like 'Boulevard%' THEN 4 WHEN nom LIKE 'Place%' THEN 4 WHEN nom LIKE 'Espl%' THEN 4 WHEN nom LIKE 'Av%' THEN 3 WHEN nom LIKE 'Rue %' THEN 2 ELSE 1 END))::numeric,4)::float
        END AS importance,
        source,
-       RANK() OVER (PARTITION BY fantoir ORDER BY CASE source WHEN 'OSM' THEN 1 ELSE 2 END, CASE nature WHEN 'centroide' THEN 2 ELSE 1 END,pp.id) AS rang_par_fantoir,
+       ROW_NUMBER() OVER (PARTITION BY fantoir ORDER BY CASE source WHEN 'OSM' THEN 1 ELSE 2 END, CASE nature WHEN 'centroide' THEN 2 ELSE 1 END,pp.id) AS rang_par_fantoir,
        c.dep
 FROM   set_fantoir
 JOIN   bano_points_nommes AS pn


### PR DESCRIPTION
La sortie de BANO contient des voies en doublons. C'est causé par des jointures multiples.

Cela vient de `WHERE  rang_par_fantoir = 1` qui n'est pas unique. La fonction `RANK()` peut renvoyer des execos, contrairement à la fonction `ROW_NUMBER()`.

Les doublons viennent à l'origine des données OSM.

Je pense qu'il faut repasser sur tous les `RANK()` avec `WHERE rank=1` pour les vérifier/corriger.
