### PR TITLE
Use old_name and alt_name fields

### DIFF
--- a/bano/sql/charge_noms_voies_lieux-dits_OSM.sql
+++ b/bano/sql/charge_noms_voies_lieux-dits_OSM.sql
@@ -7,7 +7,7 @@ SELECT  DISTINCT provenance,
         nature
 FROM    (SELECT  1::integer AS provenance,
                  pt.way,
-                 UNNEST(ARRAY[pt.name,pt.tags->'alt_name',pt.tags->'old_name']) as name,
+                 UNNEST(ARRAY[pt.name,pt.alt_name,pt.old_name]) as name,
                  tags,
                  CASE
                      WHEN pt.place='' THEN 'voie'::text
@@ -20,7 +20,7 @@ FROM    (SELECT  1::integer AS provenance,
          UNION ALL
          SELECT  2,
                  l.way,
-                 UNNEST(ARRAY[l.name,l.tags->'alt_name',l.tags->'old_name']) as name,
+                 UNNEST(ARRAY[l.name,l.alt_name,l.old_name]) as name,
                  tags,
                  'voie'
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__') p
@@ -29,7 +29,7 @@ FROM    (SELECT  1::integer AS provenance,
          UNION ALL
          SELECT  3,
                  pl.way,
-                 UNNEST(ARRAY[pl.name,pl.tags->'alt_name',pl.tags->'old_name']) as name,
+                 UNNEST(ARRAY[pl.name,pl.alt_name,pl.old_name]) as name,
                  tags,
                  'voie'
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')                                                                    p

--- a/bano/sql/charge_noms_voies_relation_OSM.sql
+++ b/bano/sql/charge_noms_voies_relation_OSM.sql
@@ -6,21 +6,21 @@ SELECT  DISTINCT provenance,
         a9.nom,
         'voie'::text
 FROM    (SELECT 4::integer AS provenance,
-                UNNEST(ARRAY[l.name,l.tags->'alt_name',l.tags->'old_name']) as name,
+                UNNEST(ARRAY[l.name,l.alt_name,l.old_name]) as name,
                 l.way,
                 r.tags
          FROM   (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')    p
-         JOIN   (SELECT name,tags,osm_id,way FROM planet_osm_line WHERE highway != '' AND name != '') l
+         JOIN   (SELECT name,alt_name,old_name,tags,osm_id,way FROM planet_osm_line WHERE highway != '' AND name != '') l
          ON     p.way && l.way AND ST_Contains(p.way, l.way)
          JOIN   planet_osm_rels r
          ON     r.osm_id = l.osm_id
          UNION ALL
          SELECT 5,
-                UNNEST(ARRAY[l.name,l.tags->'alt_name',l.tags->'old_name']) as name,
+                UNNEST(ARRAY[l.name,l.alt_name,l.old_name]) as name,
                 l.way,
                 r.tags
          FROM   (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')    p
-         JOIN   (SELECT name,tags,osm_id,way FROM planet_osm_polygon WHERE highway != '' AND name != '') l
+         JOIN   (SELECT name,alt_name,old_name,tags,osm_id,way FROM planet_osm_polygon WHERE highway != '' AND name != '') l
          ON     p.way && l.way AND ST_Contains(p.way, l.way)
          JOIN   planet_osm_rels r
          ON     r.osm_id = l.osm_id) l

--- a/bano/sql/charge_points_nommes_centroides_OSM.sql
+++ b/bano/sql/charge_points_nommes_centroides_OSM.sql
@@ -2,7 +2,7 @@ WITH
 lignes_brutes
 AS
 (SELECT l.way,
-        unnest(array[l.name,l.tags->'alt_name',l.tags->'old_name']) AS name,
+        unnest(array[l.name,l.alt_name,l.old_name]) AS name,
         COALESCE(a9.code_insee,'xxxxx') as insee_jointure,
         a9.code_insee insee_ac,
         unnest(array["ref:FR:FANTOIR","ref:FR:FANTOIR:left","ref:FR:FANTOIR:right"]) AS fantoir,
@@ -19,7 +19,7 @@ WHERE   (l.highway != '' OR
         l.name != ''
 UNION ALL
 SELECT  ST_PointOnSurface(l.way),
-        unnest(array[l.name,l.tags->'alt_name',l.tags->'old_name']) AS name,
+        unnest(array[l.name,l.alt_name,l.old_name]) AS name,
         COALESCE(a9.code_insee,'xxxxx') as insee_jointure,
         a9.code_insee insee_ac,
         "ref:FR:FANTOIR" AS fantoir,
@@ -35,7 +35,7 @@ WHERE   (l.highway||"ref:FR:FANTOIR" != '' OR l.landuse = 'residential' OR l.ame
         l.name != ''
 UNION ALL
 SELECT l.way,
-        unnest(array[l.name,l.tags->'alt_name',l.tags->'old_name']) AS name,
+        unnest(array[l.name,l.alt_name,l.old_name]) AS name,
         COALESCE(a9.code_insee,'xxxxx') as insee_jointure,
         a9.code_insee insee_ac,
         "ref:FR:FANTOIR" AS fantoir,
@@ -50,7 +50,7 @@ WHERE   l.member_role = 'street' AND
         l.name != ''),
 lignes_noms
 AS
-(SELECT CASE 
+(SELECT CASE
             WHEN GeometryType(way) = 'POINT' THEN ST_MakeLine(ST_Translate(way,-0.000001,-0.000001),ST_Translate(way,0.000001,0.000001))
             WHEN GeometryType(way) LIKE '%POLYGON' THEN ST_ExteriorRing(way)
             ELSE way

--- a/bano/sql/charge_points_nommes_places_OSM.sql
+++ b/bano/sql/charge_points_nommes_places_OSM.sql
@@ -2,12 +2,12 @@ WITH
 pts
 AS
 (SELECT  pt.way,
-        UNNEST(ARRAY[pt.name,pt.tags->'alt_name',pt.tags->'old_name']) as name,
+        UNNEST(ARRAY[pt.name,pt.alt_name,pt.old_name]) as name,
         tags,
         place,
         a9.code_insee AS insee_ac,
         "ref:FR:FANTOIR" AS fantoir,
-        a9.nom AS nom_ac 
+        a9.nom AS nom_ac
 FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')                    p
 JOIN    (SELECT * FROM planet_osm_point WHERE place != '' AND name != '') pt
 ON      pt.way && p.way                 AND


### PR DESCRIPTION
Ce PR reprend une partie du PR #400 pour pouvoir passer une partie des changements plus facilement et éviter les conflits avec d'autres PR.


Utilise directement les champs `alt_name` et `old_name` sans passer par `tags`.
