### PR TITLE
Pourvoir retrouver le nom OSM par défaut

### DIFF
--- a/bano/models.py
+++ b/bano/models.py
@@ -15,6 +15,7 @@ class Nom:
     def __init__(
         self,
         nom,
+        nom_tag,
         fantoir,
         nature,
         source,
@@ -26,6 +27,7 @@ class Nom:
         self.code_dept = hp.get_code_dept_from_insee(code_insee)
         self.code_insee_ancienne_commune = code_insee_ancienne_commune
         self.nom = nom.replace("\t", " ")
+        self.nom_tag = nom_tag
         self.nom_ancienne_commune = nom_ancienne_commune
         self.fantoir = fantoir[0:9] if fantoir else None
         self.nature = nature
@@ -64,7 +66,7 @@ class Nom:
             fantoir = remplace_fantoir_ban(correspondance, self.niveau, self.fantoir)
         else:
             fantoir = self.fantoir
-        return f"{fantoir}\t{self.nom}\t{self.nature}\t{self.code_insee}\t{self.code_dept}\t{self.code_insee_ancienne_commune if self.code_insee_ancienne_commune else ''}\t{self.nom_ancienne_commune if self.nom_ancienne_commune else ''}\t{self.source}"
+        return f"{fantoir}\t{self.nom}\t{self.nom_tag}\t{self.nature}\t{self.code_insee}\t{self.code_dept}\t{self.code_insee_ancienne_commune if self.code_insee_ancienne_commune else ''}\t{self.nom_ancienne_commune if self.nom_ancienne_commune else ''}\t{self.source}"
 
     def add_fantoir(self, topo):
         if not self.fantoir:
@@ -104,6 +106,7 @@ class Noms:
         for (
             provenance,
             name,
+            name_tag,
             tags,
             libelle_suffixe,
             code_insee_ancienne_commune,
@@ -114,6 +117,7 @@ class Noms:
                 self.add_nom(
                     Nom(
                         name,
+                        name_tag,
                         tags.get("ref:FR:FANTOIR"),
                         nature,
                         "OSM",
@@ -126,6 +130,7 @@ class Noms:
                 self.add_nom(
                     Nom(
                         name,
+                        name_tag,
                         tags["ref:FR:FANTOIR"],
                         nature,
                         "OSM",
@@ -199,6 +204,7 @@ class Noms:
                 columns=(
                     "fantoir",
                     "nom",
+                    "nom_tag",
                     "nature",
                     "code_insee",
                     "code_dept",
@@ -462,6 +468,7 @@ class Adresses:
                 noms.add_nom(
                     Nom(
                         a.voie,
+                        None,
                         a.fantoir,
                         "voie",
                         a.source,
@@ -474,6 +481,7 @@ class Adresses:
                 noms.add_nom(
                     Nom(
                         a.place,
+                        None,
                         a.fantoir,
                         "place",
                         a.source,
@@ -556,6 +564,7 @@ class Point_nomme:
         lon,
         lat,
         nom,
+        nom_tag,
         fantoir=None,
         code_insee_ancienne_commune=None,
         nom_ancienne_commune=None,
@@ -567,6 +576,7 @@ class Point_nomme:
         self.lat = round(lat, 6)
         self.nature = nature
         self.nom = nom.replace("\t", " ")
+        self.nom_tag = nom_tag
         self.nom_normalise = hp.normalize(nom)
         self.fantoir = fantoir[0:9] if fantoir else None
         self.code_insee_ancienne_commune = code_insee_ancienne_commune
@@ -627,6 +637,7 @@ class Points_nommes:
                     x,
                     y,
                     hp.format_toponyme(nom),
+                    None,
                     code_insee_ancienne_commune=code_insee_ancienne_commune,
                     nom_ancienne_commune=nom_ancienne_commune,
                 )
@@ -641,6 +652,7 @@ class Points_nommes:
             x,
             y,
             nom,
+            nom_tag,
             code_insee_ancienne_commune,
             fantoir,
             nom_ancienne_commune,
@@ -658,11 +670,12 @@ class Points_nommes:
                         x,
                         y,
                         nom,
+                        nom_tag,
                         code_insee_ancienne_commune=code_insee_ancienne_commune,
                         fantoir=single_fantoir,
                         nom_ancienne_commune=nom_ancienne_commune,
                     )
-            )
+                )
 
     def charge_points_nommes_place_osm(self):
         data = sql_get_data(
@@ -673,6 +686,7 @@ class Points_nommes:
             x,
             y,
             nom,
+            nom_tag,
             code_insee_ancienne_commune,
             fantoir,
             nom_ancienne_commune,
@@ -688,11 +702,12 @@ class Points_nommes:
                         x,
                         y,
                         nom,
+                        nom_tag,
                         code_insee_ancienne_commune=code_insee_ancienne_commune,
                         fantoir=single_fantoir,
                         nom_ancienne_commune=nom_ancienne_commune,
                     )
-            )
+                )
 
     def charge_points_nommes_numeros_ban(self):
         data = sql_get_data(
@@ -715,6 +730,7 @@ class Points_nommes:
                     x,
                     y,
                     nom,
+                    None,
                     code_insee_ancienne_commune=code_insee_ancienne_commune,
                     fantoir=fantoir,
                     nom_ancienne_commune=nom_ancienne_commune,
@@ -730,6 +746,7 @@ class Points_nommes:
                 noms.add_nom(
                     Nom(
                         a.nom,
+                        None,
                         a.fantoir,
                         a.nature,
                         a.source,
@@ -742,6 +759,7 @@ class Points_nommes:
                 noms.add_nom(
                     Nom(
                         a.nom,
+                        a.nom_tag,
                         a.fantoir,
                         a.nature,
                         a.source,

--- a/bano/models.py
+++ b/bano/models.py
@@ -66,7 +66,7 @@ class Nom:
             fantoir = remplace_fantoir_ban(correspondance, self.niveau, self.fantoir)
         else:
             fantoir = self.fantoir
-        return f"{fantoir}\t{self.nom}\t{self.nom_tag}\t{self.nature}\t{self.code_insee}\t{self.code_dept}\t{self.code_insee_ancienne_commune if self.code_insee_ancienne_commune else ''}\t{self.nom_ancienne_commune if self.nom_ancienne_commune else ''}\t{self.source}"
+        return f"{fantoir}\t{self.nom}\t{self.nom_tag if self.nom_tag else ''}\t{self.nature}\t{self.code_insee}\t{self.code_dept}\t{self.code_insee_ancienne_commune if self.code_insee_ancienne_commune else ''}\t{self.nom_ancienne_commune if self.nom_ancienne_commune else ''}\t{self.source}"
 
     def add_fantoir(self, topo):
         if not self.fantoir:

--- a/bano/sql/charge_noms_voies_lieux-dits_OSM.sql
+++ b/bano/sql/charge_noms_voies_lieux-dits_OSM.sql
@@ -1,5 +1,6 @@
 SELECT  DISTINCT provenance,
         name,
+        name_tag,
         tags,
         libelle_suffixe,
         a9.code_insee,
@@ -7,7 +8,8 @@ SELECT  DISTINCT provenance,
         nature
 FROM    (SELECT  1::integer AS provenance,
                  pt.way,
-                 UNNEST(ARRAY[pt.name,pt.alt_name,pt.old_name]) as name,
+                 name_osm.name,
+                 name_osm.name_tag,
                  tags,
                  CASE
                      WHEN pt.place='' THEN 'voie'::text
@@ -16,26 +18,41 @@ FROM    (SELECT  1::integer AS provenance,
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')                    p
          JOIN    (SELECT * FROM planet_osm_point WHERE ("ref:FR:FANTOIR" !='' OR place != '') AND name != '') pt
          ON      pt.way && p.way                 AND
-                 ST_Intersects(pt.way, p.way)
+                 ST_Intersects(pt.way, p.way),
+         UNNEST(
+             ARRAY [pt.name,pt.alt_name,pt.old_name],
+             ARRAY ['name','alt_name','old_name']
+         ) AS name_osm(name,name_tag)
          UNION ALL
          SELECT  2,
                  l.way,
-                 UNNEST(ARRAY[l.name,l.alt_name,l.old_name]) as name,
+                 name_osm.name,
+                 name_osm.name_tag,
                  tags,
                  'voie'
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__') p
          JOIN    (SELECT * FROM planet_osm_line WHERE highway != '' AND name != '')        l
-         ON      p.way && l.way AND ST_Contains(p.way, l.way)
+         ON      p.way && l.way AND ST_Contains(p.way, l.way),
+         UNNEST(
+             ARRAY [l.name,l.alt_name,l.old_name],
+             ARRAY ['name','alt_name','old_name']
+         ) AS name_osm(name,name_tag)
          UNION ALL
          SELECT  3,
                  pl.way,
-                 UNNEST(ARRAY[pl.name,pl.alt_name,pl.old_name]) as name,
+                 name_osm.name,
+                 name_osm.name_tag,
                  tags,
                  'voie'
          FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')                                                                    p
          JOIN    (SELECT * FROM planet_osm_polygon WHERE (highway||"ref:FR:FANTOIR" != '' OR landuse = 'residential' OR amenity = 'parking') AND name != '') pl
          ON      pl.way && p.way                 AND
-                 ST_Intersects(pl.way, p.way)) l
+                 ST_Intersects(pl.way, p.way),
+         UNNEST(
+             ARRAY [pl.name,pl.alt_name,pl.old_name],
+             ARRAY ['name','alt_name','old_name']
+         ) AS name_osm(name,name_tag)
+) l
 LEFT OUTER JOIN suffixe h
 ON      ST_Intersects(l.way, h.geometrie)
 LEFT OUTER JOIN (SELECT * FROM polygones_insee_a9 where insee_a8 = '__code_insee__') a9

--- a/bano/sql/charge_noms_voies_relation_OSM.sql
+++ b/bano/sql/charge_noms_voies_relation_OSM.sql
@@ -1,29 +1,41 @@
 SELECT  DISTINCT provenance,
         name,
+        name_tag,
         tags,
         libelle_suffixe,
         a9.code_insee,
         a9.nom,
         'voie'::text
 FROM    (SELECT 4::integer AS provenance,
-                UNNEST(ARRAY[l.name,l.alt_name,l.old_name]) as name,
+                name_osm.name,
+                name_osm.name_tag,
                 l.way,
                 r.tags
          FROM   (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')    p
          JOIN   (SELECT name,alt_name,old_name,tags,osm_id,way FROM planet_osm_line WHERE highway != '' AND name != '') l
          ON     p.way && l.way AND ST_Contains(p.way, l.way)
          JOIN   planet_osm_rels r
-         ON     r.osm_id = l.osm_id
+         ON     r.osm_id = l.osm_id,
+         UNNEST(
+             ARRAY [l.name,l.alt_name,l.old_name],
+             ARRAY ['name','alt_name','old_name']
+         ) AS name_osm(name,name_tag)
          UNION ALL
          SELECT 5,
-                UNNEST(ARRAY[l.name,l.alt_name,l.old_name]) as name,
+                name_osm.name,
+                name_osm.name_tag,
                 l.way,
                 r.tags
          FROM   (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__')    p
          JOIN   (SELECT name,alt_name,old_name,tags,osm_id,way FROM planet_osm_polygon WHERE highway != '' AND name != '') l
          ON     p.way && l.way AND ST_Contains(p.way, l.way)
          JOIN   planet_osm_rels r
-         ON     r.osm_id = l.osm_id) l
+         ON     r.osm_id = l.osm_id,
+         UNNEST(
+                ARRAY [l.name,l.alt_name,l.old_name],
+                ARRAY ['name','alt_name','old_name']
+         ) AS name_osm(name,name_tag)
+) l
 LEFT OUTER JOIN (SELECT * FROM suffixe WHERE code_insee = '__code_insee__') h
 ON       ST_Intersects(way, h.geometrie)
 LEFT OUTER JOIN (SELECT * FROM polygones_insee_a9 where insee_a8 = '__code_insee__') a9

--- a/bano/sql/charge_noms_voies_relation_bbox_OSM.sql
+++ b/bano/sql/charge_noms_voies_relation_bbox_OSM.sql
@@ -1,5 +1,6 @@
 SELECT  DISTINCT provenance,
         name,
+        'name' AS name_tag,
         tags,
         libelle_suffixe,
         a9.code_insee,

--- a/bano/sql/create_table_base_bano_cibles.sql
+++ b/bano/sql/create_table_base_bano_cibles.sql
@@ -52,6 +52,7 @@ CREATE INDEX IF NOT EXISTS idx_bano_points_nommes_code_dept_nature ON bano_point
 CREATE TABLE IF NOT EXISTS nom_fantoir (
     fantoir text,
     nom text,
+    nom_tag text,
     code_insee text,
     code_dept text,
     nature text,

--- a/bano/sql/tables_export.sql
+++ b/bano/sql/tables_export.sql
@@ -28,7 +28,12 @@ AS
         nom
 FROM    (SELECT fantoir,
                 nom,
-                RANK() OVER (PARTITION BY fantoir ORDER BY CASE WHEN source = 'OSM' THEN 1 ELSE 2 END, CASE nature WHEN 'lieu-dit' THEN 1 WHEN 'place' THEN 1 WHEN 'voie' THEN 2 ELSE 3 END, nom ) AS rang
+                RANK() OVER (PARTITION BY fantoir ORDER BY
+                    CASE WHEN source = 'OSM' THEN 1 ELSE 2 END,
+                    CASE nature WHEN 'lieu-dit' THEN 1 WHEN 'place' THEN 1 WHEN 'voie' THEN 2 ELSE 3 END,
+                    CASE WHEN nom_tag = 'name' THEN 1 ELSE 2 END,
+                    nom
+                ) AS rang
         FROM    nom_fantoir) n
 WHERE rang = 1
 GROUP BY 1,2),
@@ -51,7 +56,7 @@ FROM    num_norm_id n
 JOIN    nom_fantoir nf
 USING   (fantoir)
 JOIN    (SELECT dep, com, libelle FROM cog_commune WHERE typecom in ('ARM','COM')) cn
-ON      (cn.com = code_insee) 
+ON      (cn.com = code_insee)
 LEFT OUTER JOIN    polygones_postaux pp
 ON      ST_Contains(pp.geometrie, n.geometrie)
 LEFT OUTER JOIN cp_fantoir
@@ -71,7 +76,7 @@ SELECT fantoir,
        count(*) AS nombre_adresses
 FROM   numeros_export
 GROUP BY fantoir;
-         
+
 
 DROP TABLE IF EXISTS export_voies_adresses_json CASCADE;
 CREATE TABLE export_voies_adresses_json


### PR DESCRIPTION
PR base sur le PR #418 - a merger avant.

Le code actuel utilise `UNNEST(ARRAY[pt.name,pt.tags->'alt_name',pt.tags->'old_name'])` pour récupérer les noms depuis les tags OSM. Contraintement à un `COALESCE`, le `UNNEST` peut récupérer plusieurs noms.

Dans le cas où l'on a plusieurs noms les traitements suivant récupère un nom OSM en priorité, sans garantie duquel.

Ce PR garde le nom du tag OSM duquel est issue le nom en parallèle du nom.

Ce qui permet ensuite de prioriser le nom par défaut (tag OSM `name`) aux autres noms issues d'OSM.

C'est attribut `osm_tag` pourrait ensuite être utilisé dans d'autres PR pour connaître la langue du nom (et pourquoi pas l’indiquer dans le fichier de sortie).

J'ai découvert ce problème en travaillant sur des noms multilingues, ou l'on n'était plus en capacité d'identifier le nom par défaut. Mais ce bug existe dans le code actuel, même si je n'ai pas d'exemple de sortie erronée à fournir.