### PR TITLE
Configure Osmosis

### DIFF
--- a/load_osm_france_db.sh
+++ b/load_osm_france_db.sh
@@ -33,7 +33,7 @@ REPL=${PBF_URL/extracts/replication/}
 REPL=${REPL/.osm.pbf/\/minute/}
 sed -i -e "s|baseUrl.*|baseUrl=${REPL}|" configuration.txt
 # 5 jours
-sed -i -e "s|maxInterval.*|maxInterval=432000|" configuration.txt
+sed -i -e "s|maxInterval.*|maxInterval=36000|" configuration.txt
 
 imposm import \
   -config $SCRIPT_DIR/imposm.config \

--- a/load_osm_france_db.sh
+++ b/load_osm_france_db.sh
@@ -21,6 +21,20 @@ touch ${lockfile}
 mkdir -p $DOWNLOAD_DIR
 cd $DOWNLOAD_DIR
 wget -NS $PBF_URL
+# Récupère le state.txt
+STATE_URL=${PBF_URL/.osm.pbf/.state.txt}
+wget -NS $STATE_URL
+mv `basename "${STATE_URL}"` state.txt
+
+# Configure osmosis pour les updates
+rm -f configuration.txt
+osmosis --read-replication-interval-init  workingDirectory=.
+REPL=${PBF_URL/extracts/replication/}
+REPL=${REPL/.osm.pbf/\/minute/}
+sed -i -e "s|baseUrl.*|baseUrl=${REPL}|" configuration.txt
+# 5 jours
+sed -i -e "s|maxInterval.*|maxInterval=432000|" configuration.txt
+
 imposm import \
   -config $SCRIPT_DIR/imposm.config \
   -read $DOWNLOAD_DIR/$PBF_FILE \


### PR DESCRIPTION
Il manque la configuration d'Osmosis pour pouvoir mettre les données OSM à jour.

Je propose de l'ajouter dans le scripts `load_osm_france_db.sh`. Peut-être que le `maxInterval` est à ajuster, je l'ai mis à 5j.
