### PR TITLE
Use ST_PointOnSurface even fo ways in place of ST_Centroid

### DIFF
--- a/bano/sql/charge_numeros_OSM.sql
+++ b/bano/sql/charge_numeros_OSM.sql
@@ -26,7 +26,7 @@ FROM
 		UNION ALL
 -- way avec addr:street ou addr:place
 		SELECT	2,
-				ST_Centroid(w.way),
+				ST_PointOnSurface(w.way),
 				w."addr:housenumber",
 				w."addr:street",
 				w."addr:place",
@@ -55,7 +55,7 @@ FROM
 		UNION ALL
 -- way dans relation associatedStreet
 		SELECT	4,
-				ST_Centroid(w.way),
+				ST_PointOnSurface(w.way),
 				w."addr:housenumber",
 				null,
 				null,
@@ -70,7 +70,7 @@ FROM
 		UNION ALL
 -- relation multipoly dans relation associatedStreet
 		SELECT	4,
-				ST_Centroid(w.way),
+				ST_PointOnSurface(w.way),
 				w."addr:housenumber",
 				null,
 				null,

--- a/bano/sql/charge_numeros_bbox_OSM.sql
+++ b/bano/sql/charge_numeros_bbox_OSM.sql
@@ -26,7 +26,7 @@ FROM
 		UNION
 -- way dans relation associatedStreet
 		SELECT	6,
-				ST_Centroid(w.way),
+				ST_PointOnSurface(w.way),
 				w."addr:housenumber",
 				null,
 				r.tags,

--- a/bano/sql/charge_points_nommes_centroides_OSM.sql
+++ b/bano/sql/charge_points_nommes_centroides_OSM.sql
@@ -93,7 +93,7 @@ WHERE   rang = 1
 GROUP BY 2,3,4,5,6,7),
 centroide_lignes_agregees
 AS
-(SELECT ST_Centroid(ST_LineMerge(ST_Collect(way_line))) way,
+(SELECT ST_PointOnSurface(ST_LineMerge(ST_Collect(way_line))) way,
         name,
         name_tag,
         insee_ac,
@@ -131,7 +131,7 @@ FROM    (SELECT pl.way point,
                 pl.highway NOT IN ('bus_stop','platform') AND
                 pl.name != ''
         UNION
-        SELECT  ST_Centroid(pl.way),
+        SELECT  ST_PointOnSurface(pl.way),
                 pl.name,
                 pl."ref:FR:FANTOIR" f
         FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__') p

--- a/bano/sql/charge_points_nommes_centroides_OSM.sql
+++ b/bano/sql/charge_points_nommes_centroides_OSM.sql
@@ -118,7 +118,7 @@ WHERE   rang = 1
 GROUP BY 2,3,4,5,6,7,8),
 centroide_lignes_agregees
 AS
-(SELECT ST_Centroid(ST_LineMerge(ST_Collect(way_line))) way,
+(SELECT ST_PointOnSurface(ST_LineMerge(ST_Collect(way_line))) way,
         main_name,
         name,
         name_tag,
@@ -158,7 +158,7 @@ FROM    (SELECT pl.way point,
                 pl.highway NOT IN ('bus_stop','platform') AND
                 pl.name != ''
         UNION
-        SELECT  ST_Centroid(pl.way),
+        SELECT  ST_PointOnSurface(pl.way),
                 pl.name,
                 pl."ref:FR:FANTOIR" f
         FROM    (SELECT way FROM planet_osm_polygon WHERE "ref:INSEE" = '__code_insee__') p

--- a/bano/sql/charge_points_nommes_places_OSM.sql
+++ b/bano/sql/charge_points_nommes_places_OSM.sql
@@ -44,7 +44,7 @@ UNNEST(
 ),
 polys
 AS
-(SELECT  st_centroid(pt.way) AS way,
+(SELECT  ST_PointOnSurface(pt.way) AS way,
         pt.name AS main_name,
         name_osm.name,
         name_osm.name_tag,

--- a/bano/sql/charge_points_nommes_places_OSM.sql
+++ b/bano/sql/charge_points_nommes_places_OSM.sql
@@ -42,7 +42,7 @@ UNNEST(
 ),
 polys
 AS
-(SELECT  st_centroid(pt.way) AS way,
+(SELECT  ST_PointOnSurface(pt.way) AS way,
         name_osm.name,
         name_osm.name_tag,
         tags,

--- a/bano/sql/create_table_base_bano_sources.sql
+++ b/bano/sql/create_table_base_bano_sources.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS lieux_dits (
     created date,
     updated date,
     geometrie geometry(Polygon,4326),
-    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_Centroid(geometrie)) STORED);
+    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_PointOnSurface(geometrie)) STORED);
 
 CREATE INDEX IF NOT EXISTS gidx_lieux_dits ON lieux_dits USING gist(geometrie);
 CREATE INDEX IF NOT EXISTS gidx__centroid_lieux_dits ON lieux_dits USING gist(geom_centroid);
@@ -66,7 +66,7 @@ CREATE TABLE IF NOT EXISTS cadastre_communes (
     created date,
     updated date,
     geometrie geometry(MultiPolygon,4326),
-    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_Centroid(geometrie)) STORED,
+    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_PointOnSurface(geometrie)) STORED,
     geom_3857 geometry (MultiPolygon, 3857) GENERATED ALWAYS AS (ST_Transform(geometrie,3857)) STORED);
 
 CREATE INDEX IF NOT EXISTS gidx_cadastre_communes ON cadastre_communes USING gist(geometrie);

--- a/bano/sql/create_table_base_bano_sources.sql
+++ b/bano/sql/create_table_base_bano_sources.sql
@@ -56,7 +56,7 @@ CREATE TABLE IF NOT EXISTS lieux_dits (
     created date,
     updated date,
     geometrie geometry(Polygon,4326),
-    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_Centroid(geometrie)) STORED);
+    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_PointOnSurface(geometrie)) STORED);
 
 CREATE INDEX IF NOT EXISTS gidx_lieux_dits ON lieux_dits USING gist(geometrie);
 CREATE INDEX IF NOT EXISTS gidx_centroid_lieux_dits ON lieux_dits USING gist(geom_centroid);
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS cadastre_communes (
     created date,
     updated date,
     geometrie geometry(MultiPolygon,4326),
-    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_Centroid(geometrie)) STORED,
+    geom_centroid geometry (Point, 4326) GENERATED ALWAYS AS (ST_PointOnSurface(geometrie)) STORED,
     geom_3857 geometry (MultiPolygon, 3857) GENERATED ALWAYS AS (ST_Transform(geometrie,3857)) STORED);
 
 CREATE INDEX IF NOT EXISTS gidx_cadastre_communes ON cadastre_communes USING gist(geometrie);


### PR DESCRIPTION
ST_PointOnSurface est la version de ST_Centroid qui assure que le point retourné est dans/sur l'objet en question.

ST_PointOnSurface malgré son nom fonctionnement également pour les lignes.

ST_PointOnSurface assure que le point n'est hors du polygone ou de la ligne.
