### PR TITLE
Inclus les communes sans admin_centre dans infos_communes

### DIFF
--- a/bano/sql/update_table_infos_communes.sql
+++ b/bano/sql/update_table_infos_communes.sql
@@ -5,11 +5,11 @@ statut
 AS
 (SELECT com code_insee, 1 AS statut FROM cog_commune
 UNION ALL
-SELECT burcentral, 2 AS statut FROM cog_canton 
+SELECT burcentral, 2 AS statut FROM cog_canton
 UNION ALL
-SELECT cheflieu, 3 AS statut FROM cog_arrondissement  
+SELECT cheflieu, 3 AS statut FROM cog_arrondissement
 UNION ALL
-SELECT cheflieu, 4 AS statut FROM cog_departement 
+SELECT cheflieu, 4 AS statut FROM cog_departement
 UNION ALL
 SELECT cheflieu, 5 AS statut FROM cog_region),
 adm_weight
@@ -42,7 +42,7 @@ SELECT cc.dep,
        adm_weight.adm_weight,
        pop.population,
        ROUND((pop.population::numeric/1000),1) AS population_milliers,
-       CASE 
+       CASE
          WHEN pop.population < 1000 THEN 'village'
          WHEN pop.population < 10000 THEN 'town'
          ELSE 'city'
@@ -55,9 +55,9 @@ JOIN cog_commune cc
 ON cc.com = code_insee
 LEFT OUTER JOIN pop
 USING (code_insee)
-JOIN  pp
+LEFT OUTER JOIN  pp
 USING (osm_id)
-WHERE pop.rang = 1 AND
+WHERE (pop.rang IS NULL OR pop.rang = 1) AND
       cc.typecom != 'COMD';
 
 TRUNCATE TABLE infos_communes;


### PR DESCRIPTION
Les communes sans rôle `admin_centre` ne sont pas incluses dans les fichiers de sortie.

`pop` est en `LEFT JOIN`, pour inclure le cas de `admin_centre` manquant, `pp` fait une jointure sur `pop` et doit aussi être en `LEFT JOIN`. Cette modif récupère 6 communes.

```diff
+01231
+07004
+14231
+16008
+46224
+59001
```

Cette correction n’est pas complète car pour les communes sans `admin_centre` il va encore la position de la commune. Je ne sais pas d’où récupérer cette position.