### PR TITLE
Postgres 18 virtual generated columns

### DIFF
--- a/bano/sql/create_table_base_bano_cibles.sql
+++ b/bano/sql/create_table_base_bano_cibles.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS bano_adresses (
     fantoir text,
-    bano_id text GENERATED ALWAYS AS (fantoir||'_'|| REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REGEXP_REPLACE(UPPER(numero),'^0*',''),'BIS','B'),'TER','T'),'QUATER','Q'),'QUAT','Q'),' ',''),'à','-'),';',','),'"','')) STORED,
+    bano_id text GENERATED ALWAYS AS (fantoir||'_'|| REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REGEXP_REPLACE(UPPER(numero),'^0*',''),'BIS','B'),'TER','T'),'QUATER','Q'),'QUAT','Q'),' ',''),'à','-'),';',','),'"','')),
     lon float,
     lat float,
     numero  text,

--- a/bano/sql/create_table_base_bano_sources.sql
+++ b/bano/sql/create_table_base_bano_sources.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS ban (
     -- id_ban_toponyme text,
     -- id_ban_district text,
     id_fantoir text,
-    fantoir text GENERATED ALWAYS AS (substr(id_fantoir,0,6)||substr(id_fantoir,7,10)) STORED,
+    fantoir text GENERATED ALWAYS AS (substr(id_fantoir,0,6)||substr(id_fantoir,7,10)),
     numero  text,
     rep text,
     nom_voie text,


### PR DESCRIPTION
Postgres 18 permet de déclarer des colonnes calculées comme "virtuelle". C'est à dire sans stocker les valeurs.

J'ai passé en revu toutes les colonnes calculées. Il y a deux types
- chaîne de caractère : coût d’exécution faible
- géométrie : coût d’exécution plus important, ça vaudrait peut-être le coup sur certaines, mais c’est à regarder plus en détail

Ce PR propose de passer en virtuel deux cas de chaîne de caractères sur des tables qui prennent beaucoup d'espace disque.

Sur des tables déjà existant les colonnes peuvent être supp et rajouté sans problème.