### PR TITLE
Utilise un tableau SQL à place de manipulation de chaine pour l'export json #463

### DIFF
--- a/bano/export.py
+++ b/bano/export.py
@@ -97,8 +97,8 @@ def save_as_json(dept):
                 if ';' in l['postcode']:
                     l['postcode'] = l['postcode'].split(';')
                 dict_hsnr = {}
-                for p in l['housenumbers'].split('@@@'):
-                    numero,lat,lon = p.split('$$$')
+                for p in l['housenumbers']:
+                    numero,lat,lon = p
                     dict_hsnr[numero] = dict(lat=float(lat),lon=float(lon))
                 l['housenumbers'] = dict_hsnr
                 jsonfile.write(f"{json.dumps(l,ensure_ascii=False,separators=(',',':'))}\n")

--- a/bano/sql/tables_export.sql
+++ b/bano/sql/tables_export.sql
@@ -96,7 +96,7 @@ SELECT c.dep,
        nom_dep AS departement,
        nom_reg AS region,
        ROUND(LOG(c.adm_weight+LOG(c.population+1)/3)::numeric*LOG(1+LOG(nombre_adresses+1)+LOG(longueur_max+1)+LOG(CASE WHEN nom_voie like 'Boulevard%' THEN 4 WHEN nom_voie LIKE 'Place%' THEN 4 WHEN nom_voie LIKE 'Espl%' THEN 4 WHEN nom_voie LIKE 'Av%' THEN 3 WHEN nom_voie LIKE 'Rue %' THEN 2 ELSE 1 END))::numeric,4)::float AS importance,
-       string_agg(numero||'$$$'||ROUND(ne.lat::numeric,6)::text||'$$$'||ROUND(ne.lon::numeric,6)::text,'@@@' ORDER BY numero) AS housenumbers
+       array_agg(array[numero, ROUND(ne.lat::numeric,6)::text, ROUND(ne.lon::numeric,6)::text] ORDER BY numero) AS housenumbers
 FROM   numeros_export ne
 JOIN   cog_pyramide_admin AS cog
 USING  (code_insee)


### PR DESCRIPTION
Utilise un tableau SQL à place de manipulation de chaine pour l'export json

Fix #463