### PR TITLE
Use imposm in place of osm2pgsql

### DIFF
--- a/bano.yml
+++ b/bano.yml
@@ -163,3 +163,37 @@ tables:
       - {key: 'admin_level', name: 'admin_level', type: integer}
       - {key: 'population', name: 'population_member', from_member: true, type: integer}
       - {key: 'population', name: 'population_rel', from_member: false, type: integer}
+
+  osm2pgsql_line:
+    type: linestring
+    mapping:
+      boundary: [__any__]
+      highway: [__any__]
+    filters:
+      require:
+        name: [__any__]
+        highway: [__any__]
+    columns:
+      - {name: osm_id, type: id}
+      - {name: way, type: geometry}
+      - {name: boundary, type: string}
+      - {name: admin_level, type: string}
+      - {name: highway, type: string}
+      - {name: name, type: string}
+      - {key: 'ref:INSEE', name: 'ref:INSEE', type: string}
+
+  osm2pgsql_polygon:
+    type: polygon
+    relation_types: [boundary]
+    mapping:
+      boundary: [__any__]
+    filters:
+      require:
+        'ref:INSEE': [__any__]
+    columns:
+      - {name: osm_id, type: id}
+      - {name: way, type: geometry}
+      - {name: boundary, type: string}
+      - {name: admin_level, type: string}
+      - {name: name, type: string}
+      - {key: 'ref:INSEE', name: 'ref:INSEE', type: string}

--- a/load_osm_france_db.sh
+++ b/load_osm_france_db.sh
@@ -45,6 +45,7 @@ imposm import \
   -dbschema-import osm
 
 $pgsql_BANO -f $SCRIPT_DIR/sql/finalisation.sql
+$pgsql_BANO -f $SCRIPT_DIR/sql/finalisation_osm2pgsql.sql
 
 cp $DOWNLOAD_DIR/last.state.txt $DOWNLOAD_DIR/state.txt
 rm ${lockfile}

--- a/sql/finalisation_osm2pgsql.sql
+++ b/sql/finalisation_osm2pgsql.sql
@@ -4,3 +4,6 @@ CREATE INDEX gidx_osm2pgsql_line_highway_name ON osm2pgsql_line USING gist (way)
 
 ALTER TABLE osm2pgsql_polygon ADD COLUMN uniqid serial;
 CREATE INDEX idx_osm2pgsql_polygon_ref_insee ON osm2pgsql_polygon("ref:INSEE");
+
+CREATE INDEX idx_osm2pgsql_line_osm_id ON osm2pgsql_line(osm_id);
+CREATE INDEX idx_osm2pgsql_polygon_osm_id ON osm2pgsql_polygon(osm_id);


### PR DESCRIPTION
Je ne sais pas si ça peut être intéressant. 

Mais j'ai modifié bano pour ne plus utiliser osm2pgsql. L'espace disque requis par osm2pgsql est sans comparaison avec celui pour arriver à la même chose avec imposm.
